### PR TITLE
config: generalise more things to be detected

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -5,20 +5,28 @@
 extern "C" {
 #endif
 
-#define HAVE_STDBOOL_H
+#if !defined(__has_builtin)
+#define __has_builtin(builtin) 0
+#endif
 
-#ifdef HAVE_STDBOOL_H
+#if !defined(__has_include)
+#define __has_include(include) 0
+#endif
+
+#if __STDC_VERSION__-0 >= 199901l || __has_include(<stdbool.h>)
+  #define HAVE_STDBOOL_H
   #include <stdbool.h>
 #elif !defined(__cplusplus)
   typedef char bool;
 #endif
 
-#define HAVE___BUILTIN_EXPECT
+#if __has_builtin(__builtin_expect)
+  #define HAVE___BUILTIN_EXPECT
+#endif
 
-#define HAVE___ATTRIBUTE__
-
-#ifdef HAVE___ATTRIBUTE__
-  #define CMARK_ATTRIBUTE(list) __attribute__ (list)
+#if defined(__GNUC__)
+  #define HAVE___ATTRIBUTE__
+  #define CMARK_ATTRIBUTE(list) __attribute__(list)
 #else
   #define CMARK_ATTRIBUTE(list)
 #endif
@@ -29,44 +37,6 @@ extern "C" {
   #else
     #define CMARK_INLINE inline
   #endif
-#endif
-
-/* snprintf and vsnprintf fallbacks for MSVC before 2015,
-   due to Valentin Milea http://stackoverflow.com/questions/2915672/
-*/
-
-#if defined(_MSC_VER) && _MSC_VER < 1900
-
-#include <stdio.h>
-#include <stdarg.h>
-
-#define snprintf c99_snprintf
-#define vsnprintf c99_vsnprintf
-
-CMARK_INLINE int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
-{
-    int count = -1;
-
-    if (size != 0)
-        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
-    if (count == -1)
-        count = _vscprintf(format, ap);
-
-    return count;
-}
-
-CMARK_INLINE int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
-{
-    int count;
-    va_list ap;
-
-    va_start(ap, format);
-    count = c99_vsnprintf(outBuf, size, format, ap);
-    va_end(ap);
-
-    return count;
-}
-
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This converts many of the checks to be dynamic to support different
compilers.  Windows uses cl which does not support `__builtin_expect`
nor does it support `__attribute__`.  This should help repair the
Windows build.