### PR TITLE
Revert "[CMake] Export the CMark targets"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,9 +142,6 @@ if(CMARK_SHARED OR CMARK_STATIC)
   export(TARGETS ${CMARK_INSTALL} FILE cmarkTargets.cmake)
 endif()
 
-export(TARGETS ${PROGRAM} ${LIBRARY} ${STATICLIBRARY}
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/CMarkExports.cmake)
-
 # Feature tests
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)


### PR DESCRIPTION
This reverts commit 5ef30d339b40df66e2ce4723f0c938512a67e260.  Upstream
now properly exports the targets which we can use.