### PR TITLE
Use quoted includes for cmark_export.h and cmark_version.h

### DIFF
--- a/src/cmark.h
+++ b/src/cmark.h
@@ -2,8 +2,8 @@
 #define CMARK_H
 
 #include <stdio.h>
-#include <cmark_export.h>
-#include <cmark_version.h>
+#include "cmark_export.h"
+#include "cmark_version.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Otherwise, using this as a Swift package causes the following error:

```
Include of non-modular header inside framework module 'cmark'
```