### PR TITLE
refactor: separate CJK-friendly Emphasis as an extension

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -1618,13 +1618,18 @@ static void cjk_emphasis(test_batch_runner *runner) {
     "<p>**“︁Git”︁**Hub</p>\n"
     "<p>“︁Git”︁<strong>Hub</strong></p>\n";
 
-  cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+  cmark_gfm_core_extensions_ensure_registered();
+  cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
+  cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("cjk_friendly_emphasis"));
+  cmark_parser_feed(parser, markdown, sizeof(markdown) - 1);
+  cmark_node *doc = cmark_parser_finish(parser);
 
   char *html = cmark_render_html(doc, CMARK_OPT_DEFAULT, NULL);
   STR_EQ(runner, html, expected_html, "emphasis parsing with CJK didn't generate expected HTML");
 
   free(html);
   cmark_node_free(doc);
+  cmark_parser_free(parser);
 }
 
 static void cjk_emoji_emphasis(test_batch_runner *runner) {
@@ -1696,13 +1701,40 @@ static void cjk_emoji_emphasis(test_batch_runner *runner) {
     "<p>テスト⌛<strong>テスト？</strong>テスト</p>\n"
     "<p>テスト⌛<strong>テスト</strong>？テスト</p>\n";
 
-  cmark_node *doc = cmark_parse_document(markdown, sizeof(markdown) - 1, CMARK_OPT_DEFAULT);
+  cmark_gfm_core_extensions_ensure_registered();
+  cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
+  cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("cjk_friendly_emphasis"));
+  cmark_parser_feed(parser, markdown, sizeof(markdown) - 1);
+  cmark_node *doc = cmark_parser_finish(parser);
 
   char *html = cmark_render_html(doc, CMARK_OPT_DEFAULT, NULL);
   STR_EQ(runner, html, expected_html, "emphasis parsing with CJK and emoji didn't generate expected HTML");
 
   free(html);
   cmark_node_free(doc);
+  cmark_parser_free(parser);
+}
+
+static void cjk_strikethrough_emphasis(test_batch_runner *runner) {
+  // With CJK extension + strikethrough: CJK punctuation should not prevent flanking
+  static const char markdown[] =
+    "~~テスト。~~テスト\n";
+  static const char expected_html[] =
+    "<p><del>テスト。</del>テスト</p>\n";
+
+  cmark_gfm_core_extensions_ensure_registered();
+  cmark_parser *parser = cmark_parser_new(CMARK_OPT_DEFAULT);
+  cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("strikethrough"));
+  cmark_parser_attach_syntax_extension(parser, cmark_find_syntax_extension("cjk_friendly_emphasis"));
+  cmark_parser_feed(parser, markdown, sizeof(markdown) - 1);
+  cmark_node *doc = cmark_parser_finish(parser);
+
+  char *html = cmark_render_html(doc, CMARK_OPT_DEFAULT, cmark_parser_get_syntax_extensions(parser));
+  STR_EQ(runner, html, expected_html, "strikethrough with CJK extension should handle CJK punctuation");
+
+  free(html);
+  cmark_node_free(doc);
+  cmark_parser_free(parser);
 }
 
 int main() {
@@ -1744,6 +1776,7 @@ int main() {
   table_spans(runner);
   cjk_emphasis(runner);
   cjk_emoji_emphasis(runner);
+  cjk_strikethrough_emphasis(runner);
 
   test_print_summary(runner);
   retval = test_ok(runner) ? 0 : 1;

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(libcmark-gfm-extensions
   autolink.c
+  cjk_friendly_emphasis.c
   core-extensions.c
   ext_scanners.c
   ext_scanners.h

--- a/extensions/cjk_friendly_emphasis.c
+++ b/extensions/cjk_friendly_emphasis.c
@@ -1,0 +1,13 @@
+#include <stdbool.h>
+
+#include "cjk_friendly_emphasis.h"
+#include <parser.h>
+#include <render.h>
+
+cmark_syntax_extension *create_cjk_friendly_emphasis_extension(void) {
+  cmark_syntax_extension *ext = cmark_syntax_extension_new("cjk_friendly_emphasis");
+
+  cmark_syntax_extension_set_cjk_friendly_emphasis(ext, true);
+
+  return ext;
+}

--- a/extensions/cjk_friendly_emphasis.h
+++ b/extensions/cjk_friendly_emphasis.h
@@ -1,0 +1,8 @@
+#ifndef CMARK_GFM_CJK_FRIENDLY_EMPHASIS_H
+#define CMARK_GFM_CJK_FRIENDLY_EMPHASIS_H
+
+#include "cmark-gfm-core-extensions.h"
+
+cmark_syntax_extension *create_cjk_friendly_emphasis_extension(void);
+
+#endif

--- a/extensions/core-extensions.c
+++ b/extensions/core-extensions.c
@@ -1,5 +1,6 @@
 #include "cmark-gfm-core-extensions.h"
 #include "autolink.h"
+#include "cjk_friendly_emphasis.h"
 #include "mutex.h"
 #include "node.h"
 #include "strikethrough.h"
@@ -16,6 +17,8 @@ static int core_extensions_registration(cmark_plugin *plugin) {
   cmark_plugin_register_syntax_extension(plugin, create_autolink_extension());
   cmark_plugin_register_syntax_extension(plugin, create_tagfilter_extension());
   cmark_plugin_register_syntax_extension(plugin, create_tasklist_extension());
+  cmark_plugin_register_syntax_extension(plugin,
+                                         create_cjk_friendly_emphasis_extension());
   return 1;
 }
 

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -117,6 +117,10 @@ int cmark_parser_attach_syntax_extension(cmark_parser *parser,
       parser->mem, parser->inline_syntax_extensions, extension);
   }
 
+  if (extension->cjk_friendly_emphasis) {
+    parser->cjk_friendly_emphasis = true;
+  }
+
   return 1;
 }
 
@@ -135,6 +139,7 @@ static void cmark_parser_reset(cmark_parser *parser) {
   cmark_mem *saved_mem = parser->mem;
   int8_t *saved_specials = parser->special_chars;
   int8_t *saved_skips = parser->skip_chars;
+  bool saved_cjk_friendly_emphasis = parser->cjk_friendly_emphasis;
 
   cmark_parser_dispose(parser);
 
@@ -156,6 +161,7 @@ static void cmark_parser_reset(cmark_parser *parser) {
 
   parser->special_chars = saved_specials;
   parser->skip_chars = saved_skips;
+  parser->cjk_friendly_emphasis = saved_cjk_friendly_emphasis;
 }
 
 cmark_parser *cmark_parser_new_with_mem(int options, cmark_mem *mem) {
@@ -1082,8 +1088,8 @@ static cmark_node *check_open_blocks(cmark_parser *parser, cmark_chunk *input,
   *all_matched = false;
   cmark_node *container = parser->root;
   cmark_node_type cont_type;
-    
-    
+
+
 
   while (S_last_child_is_open(container)) {
     container = container->last_child;

--- a/src/include/cmark-gfm-extension_api.h
+++ b/src/include/cmark-gfm-extension_api.h
@@ -381,6 +381,12 @@ void cmark_syntax_extension_set_commonmark_escape_func(cmark_syntax_extension *e
 /** See the documentation for 'cmark_syntax_extension'
  */
 CMARK_GFM_EXPORT
+void cmark_syntax_extension_set_cjk_friendly_emphasis(cmark_syntax_extension *extension,
+                                                      bool cjk_friendly_emphasis);
+
+/** See the documentation for 'cmark_syntax_extension'
+ */
+CMARK_GFM_EXPORT
 void cmark_syntax_extension_set_private(cmark_syntax_extension *extension,
                                         void *priv,
                                         cmark_free_func free_func);
@@ -638,7 +644,7 @@ void cmark_inline_parser_set_offset(cmark_inline_parser *parser, int offset);
 CMARK_GFM_EXPORT
 struct cmark_chunk *cmark_inline_parser_get_chunk(cmark_inline_parser *parser);
 
-/** Returns 1 if the inline parser is currently in a bracket; pass 2 for attribute, 
+/** Returns 1 if the inline parser is currently in a bracket; pass 2 for attribute,
  * 1 for 'image' if you want to know about an image-type bracket, 0 for link-type. */
 CMARK_GFM_EXPORT
 int cmark_inline_parser_in_bracket(cmark_inline_parser *parser, int type);

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -56,6 +56,8 @@ struct cmark_parser {
   /* used when parsing inlines, can be populated by extensions if any are loaded */
   int8_t *skip_chars;
   int8_t *special_chars;
+  /* set to true when the cjk_friendly_emphasis extension is attached */
+  bool cjk_friendly_emphasis;
 };
 
 #ifdef __cplusplus

--- a/src/include/syntax_extension.h
+++ b/src/include/syntax_extension.h
@@ -30,6 +30,7 @@ struct cmark_syntax_extension {
   cmark_opaque_alloc_func         opaque_alloc_func;
   cmark_opaque_free_func          opaque_free_func;
   cmark_commonmark_escape_func    commonmark_escape_func;
+  bool                            cjk_friendly_emphasis;
 };
 
 #endif

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -68,6 +68,8 @@ typedef struct subject{
   bufsize_t backticks[MAXBACKTICKS + 1];
   bool scanned_for_backticks;
   bool no_link_openers;
+  bool cjk_friendly_emphasis;
+  int8_t *skip_chars;
 } subject;
 
 void cmark_set_default_skip_chars(int8_t **skip_chars, bool use_memcpy) {
@@ -211,6 +213,8 @@ static void subject_from_buf(cmark_mem *mem, int line_number, int block_offset, 
   }
   e->scanned_for_backticks = false;
   e->no_link_openers = true;
+  e->cjk_friendly_emphasis = false;
+  e->skip_chars = NULL;
 }
 
 static inline int isbacktick(int c) { return (c == '`'); }
@@ -428,12 +432,16 @@ static cmark_node *handle_backticks(subject *subj, int options) {
 static int scan_delims(cmark_parser *parser, subject *subj, unsigned char c,
                        bool *can_open, bool *can_close) {
   int numdelims = 0;
-  bufsize_t before_char_pos, after_char_pos, before_before_char_pos;
+  bufsize_t before_char_pos, after_char_pos;
   int32_t after_char = 0;
   int32_t before_char = 0;
-  int32_t before_before_char = 0;
   int len;
   bool left_flanking, right_flanking;
+  bool cjk = parser->cjk_friendly_emphasis;
+
+  // CJK mode needs before_before_char for variation selector lookahead
+  bufsize_t before_before_char_pos;
+  int32_t before_before_char = 0;
 
   if (subj->pos == 0) {
     before_char = 10;
@@ -441,28 +449,42 @@ static int scan_delims(cmark_parser *parser, subject *subj, unsigned char c,
     before_char_pos = subj->pos - 1;
 
     // walk back to the beginning of the UTF_8 sequence:
-    while ((peek_at(subj, before_char_pos) >> 6 == 2 || parser->skip_chars[peek_at(subj, before_char_pos)]) && before_char_pos > 0) {
-      before_char_pos -= 1;
+    if (cjk) {
+      while ((peek_at(subj, before_char_pos) >> 6 == 2 || parser->skip_chars[peek_at(subj, before_char_pos)]) && before_char_pos > 0) {
+        before_char_pos -= 1;
+      }
+    } else {
+      while (peek_at(subj, before_char_pos) >> 6 == 2 && before_char_pos > 0) {
+        before_char_pos -= 1;
+      }
     }
     len = cmark_utf8proc_iterate(subj->input.data + before_char_pos,
                                  subj->pos - before_char_pos, &before_char);
-    if (len == -1 || (before_char < 256 && parser->skip_chars[(unsigned char) before_char])) {
-      before_char = 10;
+    if (cjk) {
+      if (len == -1 || (before_char < 256 && parser->skip_chars[(unsigned char) before_char])) {
+        before_char = 10;
+      }
+    } else {
+      if (len == -1) {
+        before_char = 10;
+      }
     }
 
-    if (before_char_pos == 0) {
-      before_before_char = 10;
-    } else {
-      before_before_char_pos = before_char_pos - 1;
-      // walk back to the beginning of the previous UTF-8 sequence again:
-      while ((peek_at(subj, before_before_char_pos) >> 6 == 2 || parser->skip_chars[peek_at(subj, before_before_char_pos)]) && before_before_char_pos > 0) {
-        before_before_char_pos -= 1;
-      }
-      len = cmark_utf8proc_iterate(subj->input.data + before_before_char_pos,
-                                   subj->pos - before_before_char_pos,
-                                   &before_before_char);
-      if (len == -1 || (before_before_char < 256 && parser->skip_chars[(unsigned char) before_before_char])) {
+    if (cjk) {
+      if (before_char_pos == 0) {
         before_before_char = 10;
+      } else {
+        before_before_char_pos = before_char_pos - 1;
+        // walk back to the beginning of the previous UTF-8 sequence again:
+        while ((peek_at(subj, before_before_char_pos) >> 6 == 2 || parser->skip_chars[peek_at(subj, before_before_char_pos)]) && before_before_char_pos > 0) {
+          before_before_char_pos -= 1;
+        }
+        len = cmark_utf8proc_iterate(subj->input.data + before_before_char_pos,
+                                     subj->pos - before_before_char_pos,
+                                     &before_before_char);
+        if (len == -1 || (before_before_char < 256 && parser->skip_chars[(unsigned char) before_before_char])) {
+          before_before_char = 10;
+        }
       }
     }
   }
@@ -482,71 +504,107 @@ static int scan_delims(cmark_parser *parser, subject *subj, unsigned char c,
   } else {
     after_char_pos = subj->pos;
 
-    while (parser->skip_chars[peek_at(subj, after_char_pos)] && after_char_pos < subj->input.len) {
-      after_char_pos += 1;
+    if (cjk) {
+      while (parser->skip_chars[peek_at(subj, after_char_pos)] && after_char_pos < subj->input.len) {
+        after_char_pos += 1;
+      }
     }
     len = cmark_utf8proc_iterate(subj->input.data + after_char_pos,
                                  subj->input.len - after_char_pos, &after_char);
-    if (len == -1 || (after_char < 256 && parser->skip_chars[(unsigned char) after_char])) {
-      after_char = 10;
+    if (cjk) {
+      if (len == -1 || (after_char < 256 && parser->skip_chars[(unsigned char) after_char])) {
+        after_char = 10;
+      }
+    } else {
+      if (len == -1) {
+        after_char = 10;
+      }
     }
   }
 
-  // a delimiter is left-flanking if it is:
-  // - not followed by whitespace, and
-  // - one of:
-  //   - not followed by a non-CJK punctuation character, or
-  //   - preceded by one of the following:
-  //     - whitespace
-  //     - a non-CJK punctuation character
-  //     - a CJK character
-  //     - an Ideographic Variation Selector
-  //     - a Non-emoji General-use Variation Selector, which is itself preceded
-  //       by one of:
-  //       - a non-CJK punctuation character, or
-  //       - a CJK character
-  left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
-                  (!cmark_utf8proc_is_non_cjk_punctuation_character(after_char) ||
-                   cmark_utf8proc_is_space(before_char) ||
-                   cmark_utf8proc_is_non_cjk_punctuation_character(before_char) ||
-                   cmark_utf8proc_is_cjk_character(before_char) ||
-                   cmark_utf8proc_is_ideographic_variation_selector(before_char) ||
-                   (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
-                    (cmark_utf8proc_is_cjk_character(before_before_char) ||
-                     cmark_utf8proc_is_non_cjk_punctuation_character(before_before_char))));
+  if (cjk) {
+    // CJK-friendly flanking rules:
+    // A delimiter is left-flanking if it is:
+    // - not followed by whitespace, and
+    // - one of:
+    //   - not followed by a non-CJK punctuation character, or
+    //   - preceded by one of the following:
+    //     - whitespace
+    //     - a non-CJK punctuation character
+    //     - a CJK character
+    //     - an Ideographic Variation Selector
+    //     - a Non-emoji General-use Variation Selector, which is itself preceded
+    //       by one of:
+    //       - a non-CJK punctuation character, or
+    //       - a CJK character
+    left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
+                    (!cmark_utf8proc_is_non_cjk_punctuation_character(after_char) ||
+                     cmark_utf8proc_is_space(before_char) ||
+                     cmark_utf8proc_is_non_cjk_punctuation_character(before_char) ||
+                     cmark_utf8proc_is_cjk_character(before_char) ||
+                     cmark_utf8proc_is_ideographic_variation_selector(before_char) ||
+                     (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
+                      (cmark_utf8proc_is_cjk_character(before_before_char) ||
+                       cmark_utf8proc_is_non_cjk_punctuation_character(before_before_char))));
 
-  // a delimiter is right flanking if it is:
-  // - not preceded by whitespace, and
-  // - one of:
-  //   - not preceded by a non-CJK punctuation sequence, i.e. one of the following:
-  //     - a non-CJK punctuation character, or
-  //     - a Non-emoji General-use Variation Selector, which is itself preceded
-  //       by a non-CJK punctuation character
-  //   - or, followed by one of the following:
-  //     - whitespace
-  //     - a non-CJK punctuation character
-  //     - a CJK character
-  right_flanking = numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
-                   (!(cmark_utf8proc_is_non_cjk_punctuation_character(before_char) ||
-                      (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
-                       cmark_utf8proc_is_non_cjk_punctuation_character(before_before_char))) ||
-                    cmark_utf8proc_is_space(after_char) ||
-                    cmark_utf8proc_is_non_cjk_punctuation_character(after_char) ||
-                    cmark_utf8proc_is_cjk_character(after_char));
-  if (c == '_') {
-    *can_open = left_flanking &&
-                (!right_flanking || cmark_utf8proc_is_punctuation(before_char) ||
-                 (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
-                  cmark_utf8proc_is_punctuation(before_before_char)));
-    *can_close = right_flanking &&
-                 (!left_flanking || cmark_utf8proc_is_punctuation(after_char));
-  } else if (c == '\'' || c == '"') {
-    *can_open = left_flanking && !right_flanking &&
-	         before_char != ']' && before_char != ')';
-    *can_close = right_flanking;
+    // A delimiter is right flanking if it is:
+    // - not preceded by whitespace, and
+    // - one of:
+    //   - not preceded by a non-CJK punctuation sequence, i.e. one of the following:
+    //     - a non-CJK punctuation character, or
+    //     - a Non-emoji General-use Variation Selector, which is itself preceded
+    //       by a non-CJK punctuation character
+    //   - or, followed by one of the following:
+    //     - whitespace
+    //     - a non-CJK punctuation character
+    //     - a CJK character
+    right_flanking = numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
+                     (!(cmark_utf8proc_is_non_cjk_punctuation_character(before_char) ||
+                        (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
+                         cmark_utf8proc_is_non_cjk_punctuation_character(before_before_char))) ||
+                      cmark_utf8proc_is_space(after_char) ||
+                      cmark_utf8proc_is_non_cjk_punctuation_character(after_char) ||
+                      cmark_utf8proc_is_cjk_character(after_char));
+
+    if (c == '_') {
+      *can_open = left_flanking &&
+                  (!right_flanking || cmark_utf8proc_is_punctuation(before_char) ||
+                   (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
+                    cmark_utf8proc_is_punctuation(before_before_char)));
+      *can_close = right_flanking &&
+                   (!left_flanking || cmark_utf8proc_is_punctuation(after_char));
+    } else if (c == '\'' || c == '"') {
+      *can_open = left_flanking && !right_flanking &&
+                  before_char != ']' && before_char != ')';
+      *can_close = right_flanking;
+    } else {
+      *can_open = left_flanking;
+      *can_close = right_flanking;
+    }
   } else {
-    *can_open = left_flanking;
-    *can_close = right_flanking;
+    // Standard CommonMark flanking rules
+    left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
+                    (!cmark_utf8proc_is_punctuation(after_char) ||
+                     cmark_utf8proc_is_space(before_char) ||
+                     cmark_utf8proc_is_punctuation(before_char));
+    right_flanking = numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
+                     (!cmark_utf8proc_is_punctuation(before_char) ||
+                      cmark_utf8proc_is_space(after_char) ||
+                      cmark_utf8proc_is_punctuation(after_char));
+
+    if (c == '_') {
+      *can_open = left_flanking &&
+                  (!right_flanking || cmark_utf8proc_is_punctuation(before_char));
+      *can_close = right_flanking &&
+                   (!left_flanking || cmark_utf8proc_is_punctuation(after_char));
+    } else if (c == '\'' || c == '"') {
+      *can_open = left_flanking && !right_flanking &&
+                  before_char != ']' && before_char != ')';
+      *can_close = right_flanking;
+    } else {
+      *can_open = left_flanking;
+      *can_close = right_flanking;
+    }
   }
   return numdelims;
 }
@@ -1761,6 +1819,8 @@ void cmark_parse_inlines(cmark_parser *parser,
   subject subj;
   cmark_chunk content = {parent->content.ptr, parent->content.size, 0};
   subject_from_buf(parser->mem, parent->start_line, parent->start_column - 1 + parent->internal_offset, &subj, &content, refmap);
+  subj.cjk_friendly_emphasis = parser->cjk_friendly_emphasis;
+  subj.skip_chars = parser->skip_chars;
   if ((options & CMARK_OPT_PRESERVE_WHITESPACE) == 0)
     cmark_chunk_rtrim(&subj.input);
 
@@ -1968,19 +2028,53 @@ int cmark_inline_parser_scan_delimiters(cmark_inline_parser *parser,
   int32_t before_char = 0;
   int len;
   bool space_before, space_after;
+  bool cjk = parser->cjk_friendly_emphasis;
+
+  // CJK mode needs before_before_char for variation selector lookahead
+  bufsize_t before_before_char_pos;
+  int32_t before_before_char = 0;
 
   if (parser->pos == 0) {
     before_char = 10;
   } else {
     before_char_pos = parser->pos - 1;
     // walk back to the beginning of the UTF_8 sequence:
-    while (peek_at(parser, before_char_pos) >> 6 == 2 && before_char_pos > 0) {
-      before_char_pos -= 1;
+    if (cjk) {
+      while ((peek_at(parser, before_char_pos) >> 6 == 2 || parser->skip_chars[peek_at(parser, before_char_pos)]) && before_char_pos > 0) {
+        before_char_pos -= 1;
+      }
+    } else {
+      while (peek_at(parser, before_char_pos) >> 6 == 2 && before_char_pos > 0) {
+        before_char_pos -= 1;
+      }
     }
     len = cmark_utf8proc_iterate(parser->input.data + before_char_pos,
                                  parser->pos - before_char_pos, &before_char);
-    if (len == -1) {
-      before_char = 10;
+    if (cjk) {
+      if (len == -1 || (before_char < 256 && parser->skip_chars[(unsigned char) before_char])) {
+        before_char = 10;
+      }
+    } else {
+      if (len == -1) {
+        before_char = 10;
+      }
+    }
+
+    if (cjk) {
+      if (before_char_pos == 0) {
+        before_before_char = 10;
+      } else {
+        before_before_char_pos = before_char_pos - 1;
+        while ((peek_at(parser, before_before_char_pos) >> 6 == 2 || parser->skip_chars[peek_at(parser, before_before_char_pos)]) && before_before_char_pos > 0) {
+          before_before_char_pos -= 1;
+        }
+        len = cmark_utf8proc_iterate(parser->input.data + before_before_char_pos,
+                                     parser->pos - before_before_char_pos,
+                                     &before_before_char);
+        if (len == -1 || (before_before_char < 256 && parser->skip_chars[(unsigned char) before_before_char])) {
+          before_before_char = 10;
+        }
+      }
     }
   }
 
@@ -1989,21 +2083,56 @@ int cmark_inline_parser_scan_delimiters(cmark_inline_parser *parser,
     advance(parser);
   }
 
-  len = cmark_utf8proc_iterate(parser->input.data + parser->pos,
-                               parser->input.len - parser->pos, &after_char);
-  if (len == -1) {
-    after_char = 10;
+  if (cjk) {
+    bufsize_t after_char_pos = parser->pos;
+    while (parser->skip_chars[peek_at(parser, after_char_pos)] && after_char_pos < parser->input.len) {
+      after_char_pos += 1;
+    }
+    len = cmark_utf8proc_iterate(parser->input.data + after_char_pos,
+                                 parser->input.len - after_char_pos, &after_char);
+    if (len == -1 || (after_char < 256 && parser->skip_chars[(unsigned char) after_char])) {
+      after_char = 10;
+    }
+  } else {
+    len = cmark_utf8proc_iterate(parser->input.data + parser->pos,
+                                 parser->input.len - parser->pos, &after_char);
+    if (len == -1) {
+      after_char = 10;
+    }
   }
 
-  *punct_before = cmark_utf8proc_is_punctuation(before_char);
-  *punct_after = cmark_utf8proc_is_punctuation(after_char);
-  space_before = cmark_utf8proc_is_space(before_char) != 0;
-  space_after = cmark_utf8proc_is_space(after_char) != 0;
+  if (cjk) {
+    *punct_before = cmark_utf8proc_is_punctuation(before_char);
+    *punct_after = cmark_utf8proc_is_punctuation(after_char);
 
-  *left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
-                  !(*punct_after && !space_before && !*punct_before);
-  *right_flanking = numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
-                  !(*punct_before && !space_after && !*punct_after);
+    *left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
+                    (!cmark_utf8proc_is_non_cjk_punctuation_character(after_char) ||
+                     cmark_utf8proc_is_space(before_char) ||
+                     cmark_utf8proc_is_non_cjk_punctuation_character(before_char) ||
+                     cmark_utf8proc_is_cjk_character(before_char) ||
+                     cmark_utf8proc_is_ideographic_variation_selector(before_char) ||
+                     (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
+                      (cmark_utf8proc_is_cjk_character(before_before_char) ||
+                       cmark_utf8proc_is_non_cjk_punctuation_character(before_before_char))));
+
+    *right_flanking = numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
+                     (!(cmark_utf8proc_is_non_cjk_punctuation_character(before_char) ||
+                        (cmark_utf8proc_is_non_emoji_general_use_variation_selector(before_char) &&
+                         cmark_utf8proc_is_non_cjk_punctuation_character(before_before_char))) ||
+                      cmark_utf8proc_is_space(after_char) ||
+                      cmark_utf8proc_is_non_cjk_punctuation_character(after_char) ||
+                      cmark_utf8proc_is_cjk_character(after_char));
+  } else {
+    *punct_before = cmark_utf8proc_is_punctuation(before_char);
+    *punct_after = cmark_utf8proc_is_punctuation(after_char);
+    space_before = cmark_utf8proc_is_space(before_char) != 0;
+    space_after = cmark_utf8proc_is_space(after_char) != 0;
+
+    *left_flanking = numdelims > 0 && !cmark_utf8proc_is_space(after_char) &&
+                    !(*punct_after && !space_before && !*punct_before);
+    *right_flanking = numdelims > 0 && !cmark_utf8proc_is_space(before_char) &&
+                    !(*punct_before && !space_after && !*punct_after);
+  }
 
   return numdelims;
 }

--- a/src/syntax_extension.c
+++ b/src/syntax_extension.c
@@ -153,3 +153,8 @@ void cmark_syntax_extension_set_commonmark_escape_func(cmark_syntax_extension *e
                                                        cmark_commonmark_escape_func func) {
   extension->commonmark_escape_func = func;
 }
+
+void cmark_syntax_extension_set_cjk_friendly_emphasis(cmark_syntax_extension *extension,
+                                                      bool cjk_friendly_emphasis) {
+  extension->cjk_friendly_emphasis = cjk_friendly_emphasis;
+}


### PR DESCRIPTION
This PR will make this extension opt-in. The fact that this extension is mandatory in the original PR #78 may be the blocker.

Warning: this is a tested slop by Copilot powered by Opus 4.6. I'm not so used to cmark-flavored C. (I understand C's syntax itself but have not got used to a lot of string/pointer operations)