### PR TITLE
Fix malformed HTML in footnote back-reference

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -74,7 +74,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
   cmark_strbuf_puts(html, m);
   cmark_strbuf_puts(html, "\" aria-label=\"Back to reference ");
   cmark_strbuf_puts(html, m);
-  cmark_strbuf_puts(html, "\xe2\x86\xa9</a>");
+  cmark_strbuf_puts(html, "\">\xe2\x86\xa9</a>");
 
   if (node->footnote.def_count > 1)
   {


### PR DESCRIPTION
The first footnote back-reference emits malformed HTML because the `aria-label` attribute and opening `<a>` tag are not closed before the back-reference arrow is written.

This changes:
```
"\xe2\x86\xa9</a>"
```
to:
```
"\">\xe2\x86\xa9</a>"
```
which produces a correctly formed back-reference:
```
<a … aria-label="Back to reference 1">↩</a>
```

This also matches the corresponding implementation in upstream github/cmark-gfm.

I reproduced the issue with multiple footnotes and verified that the back-reference arrow renders and links correctly after this change.